### PR TITLE
Make dependencies compatible with Chowda and friends

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: SonyCi
 site_description: CLAMS processing app
 repo_url: https://github.com/WGBH-MLA/sonyci
-edit_uri: ''
+edit_uri: ""
 
 markdown_extensions:
   - pymdownx.highlight
@@ -11,8 +11,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      # emoji_index: !!python/name:materialx.emoji.twemoji
+      # emoji_generator: !!python/name:materialx.emoji.to_svg
   - def_list
   - admonition
   - pymdownx.details
@@ -23,12 +23,12 @@ markdown_extensions:
 theme:
   name: material
   palette:
-    - media: '(prefers-color-scheme: dark)'
+    - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
         icon: material/lightbulb-outline
         name: Switch to light mode
-    - media: '(prefers-color-scheme: light)'
+    - media: "(prefers-color-scheme: light)"
       scheme: default
       toggle:
         icon: material/lightbulb-on-outline

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,15 +2,6 @@
 # It is not intended for manual editing.
 
 [[package]]
-name = "annotated-types"
-version = "0.4.0"
-requires_python = ">=3.7"
-summary = "Reusable constraint types to use with typing.Annotated"
-dependencies = [
-    "typing-extensions>=4.0.0; python_version < \"3.9\"",
-]
-
-[[package]]
 name = "attrs"
 version = "23.1.0"
 requires_python = ">=3.7"
@@ -413,7 +404,7 @@ summary = "A deep merge function for 🐍."
 name = "mike"
 version = "1.2.0.dev0"
 git = "https://github.com/jimporter/mike.git"
-revision = "fc7229fe6b8f3462dbf358f66ed7985785599644"
+revision = "300593c338b18f61f604d18457c351e166318020"
 summary = "Manage multiple versions of your MkDocs-powered documentation"
 dependencies = [
     "importlib-metadata",
@@ -691,22 +682,11 @@ summary = "C parser in Python"
 
 [[package]]
 name = "pydantic"
-version = "2.0a3"
+version = "1.10.7"
 requires_python = ">=3.7"
-summary = "Data validation using Python type hints"
+summary = "Data validation and settings management using python type hints"
 dependencies = [
-    "annotated-types>=0.4.0",
-    "pydantic-core==0.25.0",
     "typing-extensions>=4.2.0",
-]
-
-[[package]]
-name = "pydantic-core"
-version = "0.25.0"
-requires_python = ">=3.7"
-summary = ""
-dependencies = [
-    "typing-extensions; python_version < \"3.11.0\"",
 ]
 
 [[package]]
@@ -1057,13 +1037,9 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 [metadata]
 lock_version = "4.2"
 groups = ["default", "cli", "dev", "docs", "test"]
-content_hash = "sha256:38e88e0692265abfcc11bf6d02aa5497e876ffbbae59c2dfb292772824b76752"
+content_hash = "sha256:bd09cf8511e89272532d8fdd3ca89c509e09aa640c59f18a1bd2107bc599f5e9"
 
 [metadata.files]
-"annotated-types 0.4.0" = [
-    {url = "https://files.pythonhosted.org/packages/72/06/228244d7bc5db85719963cb957abd097ecc0e412053c70a4d3d5ef7cd5f3/annotated_types-0.4.0-py3-none-any.whl", hash = "sha256:ac27bcccc7a1447efe9a9bd1145766cc14a841b107a6040a799c260e83adf67d"},
-    {url = "https://files.pythonhosted.org/packages/ca/8e/b5223a88cdf4f9bc0d5e44d02ca9cd8c7e4a0d18b99d8b7ebd2f7dd7275f/annotated_types-0.4.0.tar.gz", hash = "sha256:fae0ca44ad43b7e54dbb02b22137885b1cb1cb7a312fe9fe7a6d77a0e5b0443a"},
-]
 "attrs 23.1.0" = [
     {url = "https://files.pythonhosted.org/packages/97/90/81f95d5f705be17872843536b1868f351805acf6971251ff07c1b8334dbb/attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
     {url = "https://files.pythonhosted.org/packages/f0/eb/fcb708c7bf5056045e9e98f62b93bd7467eb718b0202e7698eb11d66416c/attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
@@ -1696,92 +1672,43 @@ content_hash = "sha256:38e88e0692265abfcc11bf6d02aa5497e876ffbbae59c2dfb29277282
     {url = "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
     {url = "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
 ]
-"pydantic 2.0a3" = [
-    {url = "https://files.pythonhosted.org/packages/18/14/da31afdc5cc93a4b80a42cf78595fc15f5e9847b3acd8e6e0267d9568a93/pydantic-2.0a3.tar.gz", hash = "sha256:3fcf5a31489ba491b4519fb75f86d03d221a938bc8e794453cd2cfce75cb76a5"},
-    {url = "https://files.pythonhosted.org/packages/8c/90/497f95d8c3c5441fe62541b363f1d459402f385196fd8ac17546562b2286/pydantic-2.0a3-py3-none-any.whl", hash = "sha256:4bbd961e806eeeb5c9489c7352fb2cfcd0c58f80e0702065b251ce309fc8f6ec"},
-]
-"pydantic-core 0.25.0" = [
-    {url = "https://files.pythonhosted.org/packages/07/7f/576e0768b0ce0e6c03c687ed3597d912390144587238eea3e403f0d842b0/pydantic_core-0.25.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0254dce1639811384a806a77eedd24bd03554cbdafba094b03c95ba0325b5b74"},
-    {url = "https://files.pythonhosted.org/packages/0d/dc/89ed657ffa2aaa100fefb711d6fc808e108ccadf4e052b5c3728cd4780d9/pydantic_core-0.25.0-cp39-none-win32.whl", hash = "sha256:56552d6a75d2a06e7fa1fb355d6b43404490f270c49db3cd251ef074762d8c5e"},
-    {url = "https://files.pythonhosted.org/packages/10/ba/e5f87d057985e9b29174efcc8139b984c29155ba5e928b732bd4dd5833b4/pydantic_core-0.25.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4618813403b1fca7f417f1604b59c4bbe7a637275bcccff30d92b31eeffaec6e"},
-    {url = "https://files.pythonhosted.org/packages/13/53/be38dbae54240ac5166e3a54623b240c648b9cb8f76e1965ee247b4f868e/pydantic_core-0.25.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:d71a45a30286b93728c0de71733128589934008ee906b826dbcffe9fdb1d343c"},
-    {url = "https://files.pythonhosted.org/packages/18/11/eb090ac0b63fdceedb40c47d8904c60542acb651b357e158aba30b5c6db5/pydantic_core-0.25.0-cp37-cp37m-manylinux_2_24_armv7l.whl", hash = "sha256:aa3786722b293be9e8dde8a8d72cc9ed3412589755970876de6ac4167d3c0a87"},
-    {url = "https://files.pythonhosted.org/packages/1c/f8/b511d19ded8ff22af5a8d29bb59c27e9f9e5e76970bf8ae420b84a6df891/pydantic_core-0.25.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28739b0cc481dde1189ded7d691a181d61d2a8c7e503be06694bdce3586e3ecd"},
-    {url = "https://files.pythonhosted.org/packages/1e/e5/22de140f3acadb94b5b8746ba11942f094d36879dbd21b7687c429684c1d/pydantic_core-0.25.0-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:26254d3012c823c7f26d81644027a096d83c914c6f5c0893e244a9333c7aa243"},
-    {url = "https://files.pythonhosted.org/packages/23/01/03948e8419cd724311e75c3752f901ecd9908b486467290e757c1428c6a6/pydantic_core-0.25.0-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5d4e50a162d119389d7c4f0ba00021e00ec3a0b62069bf8e55cd296149a10442"},
-    {url = "https://files.pythonhosted.org/packages/26/9a/983467cf3819b8f2cd00849c65879fa77066beafac61020ae9437cc7d0eb/pydantic_core-0.25.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f88b38b223893c183d733572b815a6931adaeaaed5c986e480ea47d3f94ff67"},
-    {url = "https://files.pythonhosted.org/packages/2b/ff/a9b47c802058b973113d392ccaa158222942939c73c4d75044e8401d7921/pydantic_core-0.25.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3d76b5f7d01d2f58e34ff7460c30ee61f9a1db885a568b7904bd943c916bcd3b"},
-    {url = "https://files.pythonhosted.org/packages/2c/ca/9922c6fe85850042977b0da9041477f26427af7e1ddfc0dedbc74fc72bb0/pydantic_core-0.25.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:7e324e608e1650ccac731ae6077c7bf86f88a930a6e71b412dbe53106008e53d"},
-    {url = "https://files.pythonhosted.org/packages/2d/39/e1c87220c57df06268ddbf0bbefd9711128c1870bb85b6255c4b80c3b4fc/pydantic_core-0.25.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c81c8f78ccfe24de9a834e0c0ea1c78d9a61460b925402f4b8fd4e87ac7ba270"},
-    {url = "https://files.pythonhosted.org/packages/2e/b9/a2f192b6cc3ac01dad56a667a51e87c274665dc8f516056f0b90b85a18c0/pydantic_core-0.25.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:914ad3974d07dc17c65f46df9c896a54ac51c8bc6c657c4ab415b5d59de894cc"},
-    {url = "https://files.pythonhosted.org/packages/33/e1/19c308e11e4b13fe51394249c4db23cfa6c30411d24638ede76af5bdcb10/pydantic_core-0.25.0-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:ce0b300f5f50dfc70bf9c5eaf525600cd420c7611b0b0dc6ec62458717e955ee"},
-    {url = "https://files.pythonhosted.org/packages/36/7e/1900e564211baf565c632f11d4308dbbda4baec797edeab79ca24ab83b28/pydantic_core-0.25.0-cp37-none-win32.whl", hash = "sha256:52915248c47d414f75ccdbb496499ee83faff3a982b8886580c8dae58d411928"},
-    {url = "https://files.pythonhosted.org/packages/37/d4/37da79944c1147e9f16584402361113b23c96feb74d96928bf35f005d55d/pydantic_core-0.25.0-cp39-cp39-manylinux_2_24_s390x.whl", hash = "sha256:f1f636d2c39f694cbe82645ade8d27250fadac48bd1d47648dd0f38a487f8c51"},
-    {url = "https://files.pythonhosted.org/packages/39/04/baeac88b7026c963db7c5f7d400bd17b4d7120b450e4cf6ebb1723f20050/pydantic_core-0.25.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc8441277e75ef2026f00584511be92a8824a0ae7304fa51c8b48962665ec3c4"},
-    {url = "https://files.pythonhosted.org/packages/39/1a/089391dba3607fc074828322803a59f38a3e8e17d865716c359dadccabf6/pydantic_core-0.25.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc704bc051636ef8ef0d75d64a1e6094f96d188ca0cd772048ebbbf6863d8fc8"},
-    {url = "https://files.pythonhosted.org/packages/3c/05/64fd21f0151ad7387b3ef19e9ebbf313eb6ebb4d94c377419fbb252148fb/pydantic_core-0.25.0.tar.gz", hash = "sha256:6ed58ce669d13c076095adaea3331f48ab914485eb1ce6f462c08c982edf935e"},
-    {url = "https://files.pythonhosted.org/packages/3d/c0/4fb2bac78dc964cbcfc6f49e127524084d9642a4ba5e3ce81a7010d4c817/pydantic_core-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2fb489cd9e53efa4ea88f6c9b7cf8e4bba3cad42df3a9781bd30c072617ce1a0"},
-    {url = "https://files.pythonhosted.org/packages/3d/cf/56523e659003e262ce9fba69fff3bbf5190de563f98222b7adbaa882e227/pydantic_core-0.25.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:73287ea35d999332e443dbbdf3b9eb963c516e113bacb7f609735562a16ecc84"},
-    {url = "https://files.pythonhosted.org/packages/42/34/363940d0e2e32d07300b84f9346726f4ea092dfd9c81e07886d6c8ffacbc/pydantic_core-0.25.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bb7bb8ecb02180d62a9c751f44a5b1f126d582a866c02372f1b922a6a8e872b4"},
-    {url = "https://files.pythonhosted.org/packages/43/00/3799494f75125471e0dbb7988600b65a6afda4d1ac5a884b7412a2b1d3c8/pydantic_core-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:239ae3b0cb209244cd8d3cd74ffef0e20602aaa4c7d2718a405c324d1c7af5f0"},
-    {url = "https://files.pythonhosted.org/packages/45/79/7323e417883f8414ee6297b3e270c031f1e27aae5f8a67cb221f71c54b46/pydantic_core-0.25.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7a35610fe3c65334dc48ed6abeb459643a0becbd95a507ac3581da80d7f7a28"},
-    {url = "https://files.pythonhosted.org/packages/45/bb/63db8cda9e5c8302047cb10653955d48e7a8f2ac3592be6d3fe18e124b2f/pydantic_core-0.25.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:db6f00e16273f24342a5ed1c44aaf533c70e087d5daab01debc383015e75dde9"},
-    {url = "https://files.pythonhosted.org/packages/53/44/569d78f165ce9a35b9e9bff785c4df81f759afbb32add3c20e6cb324a8bd/pydantic_core-0.25.0-cp311-none-win_amd64.whl", hash = "sha256:1a20d538c8538f8c75ea5341dc21f94ef1882db86f2f2fd4fc61ee2a4419813a"},
-    {url = "https://files.pythonhosted.org/packages/53/ee/4637d33255080ad404953e4b5a79f881524ab54cc667da0ceada3f069e6b/pydantic_core-0.25.0-cp39-cp39-manylinux_2_24_ppc64le.whl", hash = "sha256:3fc30e7dcbc962edb649facd8d963df3c958ee762a66bc0e6bb43050497437e1"},
-    {url = "https://files.pythonhosted.org/packages/55/73/164705c21601a85769a841478328c6067f2727cb3356c740b5b71ad6800d/pydantic_core-0.25.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc17c9256540b688cd67fd3deef77dcff04ee8afe609ba418b15b43124fbc482"},
-    {url = "https://files.pythonhosted.org/packages/56/40/23d14cec862b91bd79f4c8101816e73bc4ad243319eaa9662ee1d901d09d/pydantic_core-0.25.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:09d0446252d93e1a1d4e669fc2eb429b42e66b1dd251145ebb8d17623bfc6fcc"},
-    {url = "https://files.pythonhosted.org/packages/56/a1/f7847a3cc96ca707748c7b49bd496479a347394dbf8d45f5c5abbb0e633e/pydantic_core-0.25.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:aec5b257f40f66a81df35fa9381e84dc4945ec20e1a99006a832d2bd7c730ab2"},
-    {url = "https://files.pythonhosted.org/packages/5d/c5/8a1bb942b668a416b98f87439ad4adda6b1ea1d7e8157ad88b5562c3c604/pydantic_core-0.25.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b381b02c5c70e56f9d39263ab872fe1c40d73f4609ec0d5b57c2a0489bb579d2"},
-    {url = "https://files.pythonhosted.org/packages/60/4f/d8d2d42474e1de0821413bd54b239db18129e0a7cf0508ce7d3387854cb3/pydantic_core-0.25.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b756443ba2ec6295236da587fe91a0ba99bd9131416e6163a000ae58e4724ae0"},
-    {url = "https://files.pythonhosted.org/packages/6a/34/56143e6f6ed2cebd6e513a93b6a5c3b7a83c62768804850b8b7720c6e7f1/pydantic_core-0.25.0-cp310-none-win_amd64.whl", hash = "sha256:03a152d69d5849a6820023806b8198b398b79f675ce6f72cc5a0a9ab2922a858"},
-    {url = "https://files.pythonhosted.org/packages/6e/e7/3e52d39a1ea6f5af04a48c98166a3c9d6d1b4ae6f168f7070971db33ce59/pydantic_core-0.25.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ab006970f59350f538fc01dfd1ee4fd15689490471dfc02bd68503845cd4e474"},
-    {url = "https://files.pythonhosted.org/packages/75/54/f1714f123e432e47de0c796e797a2fd05a686b898ba10a1b03242520d4dd/pydantic_core-0.25.0-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bf0de2e8f2bb0a8178a9c861a7e4cf820ddf5cab93af4f78c962e0f1c8391b38"},
-    {url = "https://files.pythonhosted.org/packages/75/a9/661b6b496323266f4fd06eb5264905d0e1daf995ef59c5607fa328c01cb6/pydantic_core-0.25.0-cp38-cp38-manylinux_2_24_s390x.whl", hash = "sha256:bff3ac8f17065e463402597f8c71c2c09045e7391a6e22ef9b43ec1c7f14999b"},
-    {url = "https://files.pythonhosted.org/packages/75/e0/421707a0d71fb0518bf30f40c0153a7ee20943c3cd1a6e285e39be0e5fde/pydantic_core-0.25.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b4fa2fbc2e4273c863abf14a73d4182b17d8d85ec5ad795de8c31dd7921a9738"},
-    {url = "https://files.pythonhosted.org/packages/7e/73/d7e068cef5a575330c055b00b278d99deaef27161d3dc2eeb268f5c3cc06/pydantic_core-0.25.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1aad4545ebfa5984095970d88c2366d6b8de2d5716f3f416ef814048371b62d0"},
-    {url = "https://files.pythonhosted.org/packages/81/a2/c2f17c1a73f78bb9ddae76e444bded68ac9535ffc8592cbb0bde70533bb7/pydantic_core-0.25.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4955568b102d57b099a3c8ec8e91f480986c55b761d3a46b69583f1381a157e6"},
-    {url = "https://files.pythonhosted.org/packages/88/b4/e819f54bf43975540579fe79c571cf4783d7702b774d8a147414fb6053b7/pydantic_core-0.25.0-cp310-cp310-manylinux_2_24_s390x.whl", hash = "sha256:8bb82dac1f0d34383b0a819544ba4c37e69a8f72c0d6e6dbbe29746147de28a3"},
-    {url = "https://files.pythonhosted.org/packages/88/bb/8401d73767d825033ea7120f0a731aa60e14e5de1e034c7fc329f18c9ed1/pydantic_core-0.25.0-cp39-cp39-manylinux_2_24_armv7l.whl", hash = "sha256:92a8b8542929f40718cb58638f46c99fcd2470c8b58d50c5fad5facac5b2fe00"},
-    {url = "https://files.pythonhosted.org/packages/8a/2b/f6d3cf776f026a32eddb44d3362bbf259b434e356fcafb64317720f7ffad/pydantic_core-0.25.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2c919d41c8e17b89d706825b7ad53a1d5834503b8222545c4751efff08cc3e8f"},
-    {url = "https://files.pythonhosted.org/packages/8b/15/69278f42cf3d2a8e09789668ffcf4b9237cbcd9a63b3b7ce6f4fb65ec003/pydantic_core-0.25.0-cp38-cp38-manylinux_2_24_armv7l.whl", hash = "sha256:93cd520418048e4ab012dba62e2cbd59f60199036a77b1e120d06f1e126232e3"},
-    {url = "https://files.pythonhosted.org/packages/8b/2f/e002b88bc3eefc50ba8b3061a8f8221aaf66b234c1853948d47fcb338319/pydantic_core-0.25.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a2a06dc032524cdad60d1a56d6a467ca649b633a6ad0315033b1d590377ade21"},
-    {url = "https://files.pythonhosted.org/packages/8d/97/1f3b0020e0640e20318693bba1d7e835df78e16c49737d9cc7adf81894ac/pydantic_core-0.25.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a68366aae4fc15b7738aacd910b10f432296f03f5fc3b622b68f4bca901206b3"},
-    {url = "https://files.pythonhosted.org/packages/90/58/2a2c12c8f5a425cec52881bf7b4071681cad7043d7a4ff478fff9ed6bc1a/pydantic_core-0.25.0-cp310-cp310-manylinux_2_24_armv7l.whl", hash = "sha256:f875acdcd51c0c72bdb046be5e1f979731ec97ed5102c55049188cd2f20a76be"},
-    {url = "https://files.pythonhosted.org/packages/95/42/212d8b25573ff40e55e2ca96e9a0cc08e96fc1ae421137326f8a29af3d74/pydantic_core-0.25.0-cp311-cp311-manylinux_2_24_ppc64le.whl", hash = "sha256:a78542cf83fa81760bc515242c7508bacca8378ebdf7f081674e0d7d07186157"},
-    {url = "https://files.pythonhosted.org/packages/97/b7/beb45fdc8ee191d096c7750a89414d069fc2dd7e1152c082ef4aee8423cf/pydantic_core-0.25.0-cp37-cp37m-manylinux_2_24_s390x.whl", hash = "sha256:fa5af4d978744e493184ecc334f23b91f93c1bf700a88fd91a6883369ab8d276"},
-    {url = "https://files.pythonhosted.org/packages/99/b2/6daec4a932c379f218a15881fb1b82e4c6ca7ee20f9f53e2145a5b6e597a/pydantic_core-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24fcfbcf31b998b4e382fb192ca6d929b32f380132dd607610290fad040e5656"},
-    {url = "https://files.pythonhosted.org/packages/a3/33/00ef00e3a398e7704e5ccd359e946c3b03538dbf827731baec1c420a284f/pydantic_core-0.25.0-cp37-cp37m-manylinux_2_24_ppc64le.whl", hash = "sha256:0fcc69217de13a6f8a926a37946e0901aec0c9b66259dde260584cd911c97aa5"},
-    {url = "https://files.pythonhosted.org/packages/ae/ff/3ed05384bcd75564a92625c5ccccdb2bf13548d3182bb51ffa23bf5ef013/pydantic_core-0.25.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d52e17b211a304f6375ef529b21869c573b866ab2bd1bf5aeba46780e7b8359"},
-    {url = "https://files.pythonhosted.org/packages/af/cd/820572c932f7aef5cea9247caf225e902f1c0a276d3cd1bc644e620f4489/pydantic_core-0.25.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17da247e12503862fe2450812cf71739787b2d813408d301bd9ba1c111167b98"},
-    {url = "https://files.pythonhosted.org/packages/b0/71/86611a4fd4aff2b91ef69c920e745228851a6ad961060cf01584ff4b11a8/pydantic_core-0.25.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15f6633fe7259e5f65ef8fd44fefc0969ab2f68744b12522ebe97e0c1fd46517"},
-    {url = "https://files.pythonhosted.org/packages/b0/aa/29c2b3d3a6f45055916cc55f3d4da8b1a71fbaaa6fba83b1881e408da812/pydantic_core-0.25.0-cp311-cp311-manylinux_2_24_s390x.whl", hash = "sha256:149c60c812ace1262008d186193a6c856d980e1913e0f7263b46c26321009efb"},
-    {url = "https://files.pythonhosted.org/packages/b5/d5/0f3302ae767b288521b3c51c069d990266b712690b3a3b698220b1ef96b9/pydantic_core-0.25.0-cp37-none-win_amd64.whl", hash = "sha256:a582fb6be0941db143944ec9f3e223d943c5410a963f969e1c813e0d941d5e30"},
-    {url = "https://files.pythonhosted.org/packages/b9/ba/86d19de9581d896a4e2bea0e85a7f1ad24c917faea867a94b97fd6583149/pydantic_core-0.25.0-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:2fb90b6df8feafc95dcd708f0bf8fbca2413f686425c0ab41916872b26ee635a"},
-    {url = "https://files.pythonhosted.org/packages/bc/d8/a6c12efaae608634ebea9237f0b0c79198a5b3b63fba53d72e24f80c2b4f/pydantic_core-0.25.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:00157f52a367d2763e05879d31d7369e22e53e6e1e196a66607452d3d229960a"},
-    {url = "https://files.pythonhosted.org/packages/c1/f8/c1bb794e1772e11f44d95e21e8b53905ee9aac3b12cee52d8971ed1d6768/pydantic_core-0.25.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:36fb117df24151ee0740e99f16f183054dfbfa7d2d0b74df195a929bb59d8259"},
-    {url = "https://files.pythonhosted.org/packages/c4/bf/f67458f8800b445686afd5630969fe74b4895cb145b63ee40f0dcb171dce/pydantic_core-0.25.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b9ede8cf2dce74599f5e90850330ecf8c0ef67575d7bc6ccda682714910b6c69"},
-    {url = "https://files.pythonhosted.org/packages/c6/a8/81b13303cbde4eb0172f3a90b271f1e2a096a6b2030a0ffc16cb40dc1baa/pydantic_core-0.25.0-cp310-none-win32.whl", hash = "sha256:43d5eb23050ba96d4f1d6f00198e8fa0d85341cfc61151d07b755f1877b4bea5"},
-    {url = "https://files.pythonhosted.org/packages/c9/22/8e3ec0fbaf950b44109942d9e0066d07abca481398f4bc2249996c273eb4/pydantic_core-0.25.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e0150ca25eeb7836aeb37ca05dd22f167d74a25fad100d58f93c20ff063c934"},
-    {url = "https://files.pythonhosted.org/packages/d1/11/27ea6086da0c064503a90a8ca706a5a8ff7cabee04e15a7c59d1df91a12a/pydantic_core-0.25.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4363bbcf28a1230b71c2437cd98234e00402bb6fd48026a134230760ca69e715"},
-    {url = "https://files.pythonhosted.org/packages/dd/b0/2e172f2cb4e75e44799a8f858c90de751a1026282fea3c9b7e934520c86e/pydantic_core-0.25.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:82bcd983fc15064928d62ade5f0352058e4ee02e809d74847e9f6d0e24736add"},
-    {url = "https://files.pythonhosted.org/packages/e6/e3/ddd4187c33c556f325e5369489e314eca3be5c9d2717baca25e1fd99fd30/pydantic_core-0.25.0-cp311-cp311-manylinux_2_24_armv7l.whl", hash = "sha256:01a0c73f018f6969e1e7393bfa0cac999c46d3ab80a8224ed15b0c641dfc96b2"},
-    {url = "https://files.pythonhosted.org/packages/eb/9e/a98e9c3f9cda7d9fb5e28bfe8037994c7b7dac23c7dd646fd4eacc011694/pydantic_core-0.25.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0c243c29bba9eb8132da3a9993a69dc295af6205f751a5d4458ff5dcdf80644c"},
-    {url = "https://files.pythonhosted.org/packages/ec/70/9b2c97fe2307af94fcde68699f4d0b6d3d70d78f1bf5ecc7b0a8b6ec219a/pydantic_core-0.25.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09a7997b8c44353d36e7a14f7eebf9c45595709198d6dd73d8b0b1f3423ec42b"},
-    {url = "https://files.pythonhosted.org/packages/ec/80/299a9a68b9826b58aa6597a5a11ed5d48e3879910bda2a8d409d5d5166df/pydantic_core-0.25.0-cp38-none-win_amd64.whl", hash = "sha256:5e4f28e67d338fb7ccc38ee39dcd35fe88ff72d2ab71336768b50077a19d4142"},
-    {url = "https://files.pythonhosted.org/packages/ed/5d/8b956f8a24451c39e1d5f92ebdf2fe3613f7ce249564100b4244412f442d/pydantic_core-0.25.0-cp38-cp38-manylinux_2_24_ppc64le.whl", hash = "sha256:35e0f3ad3817845e48b51369a602efe4cebff1127352de1551263bc5a8392399"},
-    {url = "https://files.pythonhosted.org/packages/ee/15/7c8e759d895afd5048cfec398c67843bd8d68c8112628f023379c2d5e8eb/pydantic_core-0.25.0-cp39-none-win_amd64.whl", hash = "sha256:b45581c01d6ee27c0390aa49eb2c19eaa47a6f0f0cab7fe282a9680402d1b014"},
-    {url = "https://files.pythonhosted.org/packages/ee/bd/9c8bb2fef5a09651d6d9cfcab32bd8ff5cb7b1085317dabb6901b3ef0698/pydantic_core-0.25.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:ace2e31043892352fed279fd6c1495bc66043d74b6fb04c3868e6056d3d07642"},
-    {url = "https://files.pythonhosted.org/packages/f1/63/464d481fe0919fff8ead3f5139c7a63066fc91a65509837b4fdae868dbda/pydantic_core-0.25.0-cp311-none-win32.whl", hash = "sha256:64a4fef2ff3f8e63aedc24bd8b0f4dfdd117082ec90671ea4518d51d3a21df23"},
-    {url = "https://files.pythonhosted.org/packages/f1/c5/04d389720d1899c6fddbc59e129fe34c39889f2ec71b3538133346908c4e/pydantic_core-0.25.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:97eb6422689eb714cc1f5af5d220cbbcbfbbb3778dc80f6edb578df42c94bef2"},
-    {url = "https://files.pythonhosted.org/packages/f2/35/a7093c043f0264efb7c82c4bc00c7505c55500208340e09f8541a744eb20/pydantic_core-0.25.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a548b1bdefd5d5a87dd064343e5b78e9bf7b66c64c4d2b26706f58e8f2594b6"},
-    {url = "https://files.pythonhosted.org/packages/f2/89/a9a2440104f790df755a0d5afe1ed9484bc2da2c257b05cc36f5d57804cd/pydantic_core-0.25.0-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:6234592624e74ce3b397fba6f30688a74768fed107b30bad21d44f472b243bd4"},
-    {url = "https://files.pythonhosted.org/packages/f3/19/e3ae447f6826d96a9b17768c6e6e02845ccb0bcf26d832f596250709924b/pydantic_core-0.25.0-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:ded1aabeb5f358c5ae984137e123bdb547abfa96c8f673300f8498ce832c1b9c"},
-    {url = "https://files.pythonhosted.org/packages/f5/b6/a0dc73a784071c1a95771c5840a26713397b6568954796dd1f1d331ba185/pydantic_core-0.25.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:b8358f18c1090293d6e22ed14a1ad6940421d2a10f9f276c8a2119ef5697ea67"},
-    {url = "https://files.pythonhosted.org/packages/f8/7a/78ae1f1215e6e7a3713021b1f57850c145fa47f3071262fc7b5401e21810/pydantic_core-0.25.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:2ba13d173bdd8d5d3b8d8c865cb9164bab1e9da7fd1f1fe21d3e88f3f53bfca6"},
-    {url = "https://files.pythonhosted.org/packages/f9/01/fadbfd578f1ca53a325bb0d6d316b6723a195654406209ea342fb5556870/pydantic_core-0.25.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4059c7c0e4ecf986bc864579820176e13f0896b3e0dd3b72c96298015cc1788"},
-    {url = "https://files.pythonhosted.org/packages/f9/65/324a70b320d54bebf6f3d23caa774dcf9c01e2720560a6e6cd1fe4483732/pydantic_core-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:78df29c6c8bbdb02c27443a7b9b6a32281138c92d675a0ff0891eca6657fda9f"},
-    {url = "https://files.pythonhosted.org/packages/fa/a9/46aca6b4c6b1ec13b9308a377019d12c53d243828255433f21e3059a22a2/pydantic_core-0.25.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9b5d094ad5728454e14115fed93766ae5ab89aacc218d4c641eb148bfdf0b555"},
-    {url = "https://files.pythonhosted.org/packages/fe/ee/2be26bb61d2409e6dafe4e13edf17d64489359e3deacc59ee41b8164e42f/pydantic_core-0.25.0-cp38-none-win32.whl", hash = "sha256:58b65440b8149439f541910a71c0ccf23c388553b9539c25ebebaa95759c4017"},
+"pydantic 1.10.7" = [
+    {url = "https://files.pythonhosted.org/packages/00/43/f15d991ce715a2e7a229ef7c2534527d6fe4e5d260a675bd06615a4ede82/pydantic-1.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:976cae77ba6a49d80f461fd8bba183ff7ba79f44aa5cfa82f1346b5626542f8e"},
+    {url = "https://files.pythonhosted.org/packages/05/4e/92a0c1fd305f764801dba26182b08ccf72026766fc4451d88186185467f2/pydantic-1.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe2507b8ef209da71b6fb5f4e597b50c5a34b78d7e857c4f8f3115effaef5fe"},
+    {url = "https://files.pythonhosted.org/packages/07/3a/5bc906697c9aa0f0fc28f81ec25995315c999fb6df7b29e56a49b08009a3/pydantic-1.10.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0cfe895a504c060e5d36b287ee696e2fdad02d89e0d895f83037245218a87fe"},
+    {url = "https://files.pythonhosted.org/packages/14/60/08f4b0a87561f64305002dffc5db2078043d46ed213e730a92e16840b120/pydantic-1.10.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6434b49c0b03a51021ade5c4daa7d70c98f7a79e95b551201fff682fc1661245"},
+    {url = "https://files.pythonhosted.org/packages/21/ab/d7d0f74be71041507fe7ab1a61a71b251fc7667e720323b1f51a039370bb/pydantic-1.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c230c0d8a322276d6e7b88c3f7ce885f9ed16e0910354510e0bae84d54991143"},
+    {url = "https://files.pythonhosted.org/packages/2e/97/e1e06d17f0f928083c660f6750b321797371ebd43aa16eda0ae80a4d3a7c/pydantic-1.10.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:abfb7d4a7cd5cc4e1d1887c43503a7c5dd608eadf8bc615413fc498d3e4645cd"},
+    {url = "https://files.pythonhosted.org/packages/31/9e/32896df239096e0052e390e90eb0d374367e74bf7ce603a62841310c34c7/pydantic-1.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:01aea3a42c13f2602b7ecbbea484a98169fb568ebd9e247593ea05f01b884b2e"},
+    {url = "https://files.pythonhosted.org/packages/34/d8/fd31b8172643cbf2cfd42398cba1406ea47ca1268f5e7ba48227f06c61a6/pydantic-1.10.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cc1dde4e50a5fc1336ee0581c1612215bc64ed6d28d2c7c6f25d2fe3e7c3e918"},
+    {url = "https://files.pythonhosted.org/packages/38/cb/21afb81e5b3270cf5504543fb94a0d7734c4536b98c893701842602f9da0/pydantic-1.10.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f4a2b50e2b03d5776e7f21af73e2070e1b5c0d0df255a827e7c632962f8315af"},
+    {url = "https://files.pythonhosted.org/packages/42/dc/092da33080729a95805e73084abf7cc064de7ae64462d1081859b2c1b7e2/pydantic-1.10.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75ae19d2a3dbb146b6f324031c24f8a3f52ff5d6a9f22f0683694b3afcb16fb"},
+    {url = "https://files.pythonhosted.org/packages/43/5f/e53a850fd32dddefc998b6bfcbda843d4ff5b0dcac02a92e414ba6c97d46/pydantic-1.10.7.tar.gz", hash = "sha256:cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e"},
+    {url = "https://files.pythonhosted.org/packages/5e/06/a6b6a325b4085558d48f8804433b523bf31b62e8bcad6a9f8537418240d6/pydantic-1.10.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0f85904f73161817b80781cc150f8b906d521fa11e3cdabae19a581c3606209"},
+    {url = "https://files.pythonhosted.org/packages/67/a9/f4fde01bb028c2afd0bd053ba440f7aeb609a9dc85f5d2d41a937526dbe8/pydantic-1.10.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:80b1fab4deb08a8292d15e43a6edccdffa5377a36a4597bb545b93e79c5ff0a5"},
+    {url = "https://files.pythonhosted.org/packages/67/ac/ff5f7eca22bf58dbecfd266597e15b1ec7ddc68b886157a2095a25eedb17/pydantic-1.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:68792151e174a4aa9e9fc1b4e653e65a354a2fa0fed169f7b3d09902ad2cb6f1"},
+    {url = "https://files.pythonhosted.org/packages/73/f9/860473019e228ac0b12e5cccecc086ce1f7e41d5f1482b64b9454a528e4f/pydantic-1.10.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae150a63564929c675d7f2303008d88426a0add46efd76c3fc797cd71cb1b46f"},
+    {url = "https://files.pythonhosted.org/packages/7e/2f/05c7f8dbd1de1542d7560b5e7b5aeb7d58558af2262010f8de9abb466be1/pydantic-1.10.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf135c46099ff3f919d2150a948ce94b9ce545598ef2c6c7bf55dca98a304b52"},
+    {url = "https://files.pythonhosted.org/packages/81/1b/04ce5303aee97af30b94c45699ed228b8ba6ba64c972efac184fb9a566f3/pydantic-1.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:516f1ed9bc2406a0467dd777afc636c7091d71f214d5e413d64fef45174cfc7a"},
+    {url = "https://files.pythonhosted.org/packages/83/f2/b86db67c476177ec73fce0ea87e3fa0fd686c0602efbd4e42e5ccdb2bab9/pydantic-1.10.7-cp37-cp37m-win_amd64.whl", hash = "sha256:82dffb306dd20bd5268fd6379bc4bfe75242a9c2b79fec58e1041fbbdb1f7914"},
+    {url = "https://files.pythonhosted.org/packages/8a/64/db1aafc37fab0dad89e0a27f120a18f2316fca704e9f95096ade47b933ac/pydantic-1.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:a7cd2251439988b413cb0a985c4ed82b6c6aac382dbaff53ae03c4b23a70e80a"},
+    {url = "https://files.pythonhosted.org/packages/8a/9b/4a6e7f721e54269966be968b7672f23b69d396ff59af7be6ea2e7bc30d0b/pydantic-1.10.7-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2a5ebb48958754d386195fe9e9c5106f11275867051bf017a8059410e9abf1f"},
+    {url = "https://files.pythonhosted.org/packages/8d/e1/d9219c4e4161a511158e531a84aa719087064d208c2bf87df5c58812f190/pydantic-1.10.7-py3-none-any.whl", hash = "sha256:0cd181f1d0b1d00e2b705f1bf1ac7799a2d938cce3376b8007df62b29be3c2c6"},
+    {url = "https://files.pythonhosted.org/packages/91/b8/e02d21709db955b92125059d6f80a1a543f9cc9f60ef212621514462b4e9/pydantic-1.10.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c15582f9055fbc1bfe50266a19771bbbef33dd28c45e78afbe1996fd70966c2a"},
+    {url = "https://files.pythonhosted.org/packages/a0/ef/9b9a6c4f2e520c84c86908105bdec18a06449be0b2ec5c73526eba141402/pydantic-1.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d45fc99d64af9aaf7e308054a0067fdcd87ffe974f2442312372dfa66e1001d"},
+    {url = "https://files.pythonhosted.org/packages/a4/cb/16648745548e4c18f4b98b7e323bbac698e77cd8fc250a6b2ff83688c95f/pydantic-1.10.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:464855a7ff7f2cc2cf537ecc421291b9132aa9c79aef44e917ad711b4a93163b"},
+    {url = "https://files.pythonhosted.org/packages/aa/64/1b66f84ffe07562366c5ae87e83f0b3871afefd97f0632091629e6d5cfb2/pydantic-1.10.7-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:670bb4683ad1e48b0ecb06f0cfe2178dcf74ff27921cdf1606e527d2617a81ee"},
+    {url = "https://files.pythonhosted.org/packages/b8/b7/158fb5bf629f5a97c997711757fb14e831825872c6d091a41a769c9c69e4/pydantic-1.10.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ecbbc51391248116c0a055899e6c3e7ffbb11fb5e2a4cd6f2d0b93272118a209"},
+    {url = "https://files.pythonhosted.org/packages/c8/70/8fe094a67a9431095069f6f9eb2a893e11fdaec8c1182016f53a535adfec/pydantic-1.10.7-cp38-cp38-win_amd64.whl", hash = "sha256:9f6f0fd68d73257ad6685419478c5aece46432f4bdd8d32c7345f1986496171e"},
+    {url = "https://files.pythonhosted.org/packages/c8/f3/8b3d444bdce482d6c206ab2b3ad309ae699f3074fde3d5e54c786f22b8c0/pydantic-1.10.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c7f51861d73e8b9ddcb9916ae7ac39fb52761d9ea0df41128e81e2ba42886cd"},
+    {url = "https://files.pythonhosted.org/packages/d1/a1/0aa23b545299186f6eabc7a5d289a951e6c033852938ae6673d75846e611/pydantic-1.10.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10a86d8c8db68086f1e30a530f7d5f83eb0685e632e411dbbcf2d5c0150e8dcd"},
+    {url = "https://files.pythonhosted.org/packages/d5/f0/a1bab22b297fc4333d496b34e0db42bc33c85c4b0e7e7a39da76fc65a643/pydantic-1.10.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:193924c563fae6ddcb71d3f06fa153866423ac1b793a47936656e806b64e24ca"},
+    {url = "https://files.pythonhosted.org/packages/d6/59/8082b963e077ea4bec5bb85e8c0fc636e4e7b3484e6a8ceac94e743e3b74/pydantic-1.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d"},
+    {url = "https://files.pythonhosted.org/packages/dc/01/03bb09fdb5c06075c5dc79d4c68885e87fdc7e8becf347d6a1ff8f890f79/pydantic-1.10.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:701daea9ffe9d26f97b52f1d157e0d4121644f0fcf80b443248434958fd03dc3"},
+    {url = "https://files.pythonhosted.org/packages/f1/bd/0dad4908e5f693b7951b68f435139ec583f5eebb3d75505e1efa0f2284fe/pydantic-1.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d34ab766fa056df49013bb6e79921a0265204c071984e75a09cbceacbbdd5d"},
+    {url = "https://files.pythonhosted.org/packages/f6/2d/0fc591686bc119d844f26268f503a7a504fbc9dd6a02e14aa42738c21fed/pydantic-1.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:d71e69699498b020ea198468e2480a2f1e7433e32a3a99760058c6520e2bea7e"},
+    {url = "https://files.pythonhosted.org/packages/fa/c2/3df79cd00e65678fce12e59e8c95378a992a93d7b9f9510d4f1f65df1936/pydantic-1.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:b4a849d10f211389502059c33332e91327bc154acc1845f375a99eca3afa802d"},
+    {url = "https://files.pythonhosted.org/packages/fd/66/3da2e7c0306251435bd61ae9da52db8a00672fdf2b2db1e3efe1692f41dd/pydantic-1.10.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:950ce33857841f9a337ce07ddf46bc84e1c4946d2a3bba18f8280297157a3fd1"},
 ]
 "pygments 2.15.1" = [
     {url = "https://files.pythonhosted.org/packages/34/a7/37c8d68532ba71549db4212cb036dbd6161b40e463aba336770e80c72f84/Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sonyci"
 description = "A Sony Ci api client"
 authors = [{ name = "WGBH-MLA", email = "ryan_harbert@wgbh.org" }]
 dependencies = [
-    "pydantic~=2.0a3",
+    "pydantic~=1.10",
     "requests-oauth2client~=1.1",
     "loguru~=0.7",
     "rich~=13.3",
@@ -24,7 +24,7 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest-sugar>=0.9.7",
     "pytest-xdist>=3.2.1",
-    "urllib3~=1.26"
+    "urllib3~=1.26",
 ]
 cli = ["typer[all]>=0.7.0"]
 docs = [

--- a/sonyci/sonyci.py
+++ b/sonyci/sonyci.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import Any
 
 from pydantic import BaseModel
@@ -31,7 +30,7 @@ class SonyCi(BaseModel, extra='allow'):
     client_secret: str | None = None
     workspace_id: str | None = None
 
-    @cached_property
+    @property
     def oauth(self) -> OAuth2Client:
         """Create and cache an OAuth2Client instance."""
         return OAuth2Client(
@@ -44,14 +43,14 @@ class SonyCi(BaseModel, extra='allow'):
             },
         )
 
-    @cached_property
+    @property
     def token(self) -> BearerToken:
         """Get a token from SonyCI and cache the results."""
         return get_token(
             self.username, self.password, self.client_id, self.client_secret
         )
 
-    @cached_property
+    @property
     def auth(self) -> OAuth2AccessTokenAuth:
         """Create and cache an OAuth2AccessTokenAuth instance.
 
@@ -59,7 +58,7 @@ class SonyCi(BaseModel, extra='allow'):
         """
         return OAuth2AccessTokenAuth(client=self.oauth, token=self.token)
 
-    @cached_property
+    @property
     def client(self) -> ApiClient:
         """Create and cache an ApiClient instance.
 


### PR DESCRIPTION
* Pins pydantic to v1.x to avoid bugs with Chowda.
* Pins urllib3 to v1.x to avoid problems with pytest-vcr.
* Updates pdm.lock using `pdm install -G :all` to avoid errors when trying to build locally.

Also,
* Includes some automatic edits from linters.
* Had to comment out `!!` values for keys mkdocs.yml `emoji_index` and `emoji_generator` because they are throwing "Unresolved tag" errors.