### PR TITLE
⏺️ Record

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,7 @@ def vcr_config(request):
         # Replace secrets in response body
         'before_record_response': clean_response,
     }
+
+
+def pytest_addoption(parser):
+    parser.addoption('--record', action='store_true', default=False)

--- a/tests/test_sonyci.py
+++ b/tests/test_sonyci.py
@@ -1,5 +1,3 @@
-from os import environ
-
 from pytest import fixture, mark
 
 from sonyci import SonyCi
@@ -7,8 +5,8 @@ from sonyci.config import Config
 
 
 @fixture(scope='module')
-def ci_config():
-    if environ.get('RECORD'):
+def ci_config(pytestconfig):
+    if pytestconfig.getoption('record'):
         return Config.load('./ci.toml')
     return Config.load('./tests/sonyci/sonyci.toml')
 


### PR DESCRIPTION
# `--record`
- Adds `pytest --record` option
## Usage

```py
def ci_config(pytestconfig):
    if pytestconfig.getoption('record'):
```