### PR TITLE
🚮 Un-reusable publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: 📖 Publish to PyPi
+name: 🏛 Publish to PyPi
 on:
   workflow_dispatch:
   push:
@@ -6,6 +6,40 @@ on:
       - '*'
 
 jobs:
+  build:
+    name: 📦 Build package
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📰 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📲 Setup PDM
+        uses: pdm-project/setup-pdm@v3
+        id: setup-python
+        with:
+          python-version: 3.x
+
+      - name: 🚚 Install dependencies
+        run: pdm install --prod
+
+      - name: 🏗️ Build package
+        run: pdm build
+
+      - name: 🛫 Export build files
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist
+
   publish:
-    name: 🏛 Publish package to PyPi
-    uses: WGBH-MLA/.github/.github/workflows/publish.yml@main
+    name: 🗞 Publish package
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: 🛬 Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: 🗞 Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Un-reusable publish
Reusable workflows are currently unsupported for OIDC trusted publishing: https://github.com/pypi/warehouse/issues/11096

This copies the workflow from https://github.com/WGBH-MLA/.github/blob/main/.github/workflows/publish.yml