### PR TITLE
🏞 Path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: 🛬 Download artifacts
         uses: actions/download-artifact@v3
+        with:
+          path: dist
 
       - name: 🗞 Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Path
Downloads artefacts to `path: dist`

Fixes publish workflow