### PR TITLE
🥃 dist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
       - name: 🛫 Export build files
         uses: actions/upload-artifact@v3
         with:
+          name: dist
           path: dist
 
   publish:
@@ -40,8 +41,6 @@ jobs:
     steps:
       - name: 🛬 Download artifacts
         uses: actions/download-artifact@v3
-        with:
-          path: dist
 
       - name: 🗞 Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# dist
Names publish artefact `dist` to show up as the right folder when downloaded